### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Import any settings before the `src/index.scss` file and any default settings wi
 
 # Usage with Webpack (or Create React App)
 
-First, install the webpack deps for compiling sass:
+First, install the webpack deps for compiling sass. If you are using Create React App `< v2.0.0` you will be using [react-app-rewired](https://github.com/timarney/react-app-rewired) if you haven't ejected and will require the following packages:
 
 ```
-yarn install basement sass-loader node-sass --dev
+yarn add sass-loader node-sass --dev
 ```
 
-Add the following loader to your webpack config (you'll need to use [react-app-rewired](https://github.com/timarney/react-app-rewired) if you haven't ejected):
+Add the following loader to your webpack config:
 
 ```
 {
@@ -30,6 +30,13 @@ Add the following loader to your webpack config (you'll need to use [react-app-r
 },
 ```
 
+If you are using Create React App `v2.0.0+` then SCSS modules is natively supported and you will only need to install `node-sass`:
+
+```
+yarn add node-sass --dev
+```
+
+
 Then rename your `index.css` file to `index.scss` (and be sure to change any javascript imports to `import 'index.scss';`). Sass should be working nicely, now!
 
 ---
@@ -37,7 +44,7 @@ Then rename your `index.css` file to `index.scss` (and be sure to change any jav
 Now you can install basement: 
 
 ```
-yarn install basement --dev
+yarn add 'https://github.com/sanctuarycomputer/basement.git' --dev
 ```
 
 And require it in `index.scss` like so:
@@ -47,56 +54,16 @@ And require it in `index.scss` like so:
 ```
 
 # Settings
-Spacing units for padding and margin.
-```
-$spacing-units: 0rem, .25rem, .5rem, .75rem, 1rem, 2rem, 3rem, 4rem, 6rem, 8rem;
-```
 
-Ratios for `.aspect-<ratio>` utility class.
-```
-$aspect-ratios: (
-  'square': (1, 1),
-  'landscape': (16, 9),
-  'portrait': (2, 3)
-);
-```
+Overwriting these settings is encouraged! To do so, define them in a `.scss` file and import them before Basement.
 
-Breakpoints
-```
-$breakpoints: (
-  'sm': 640px,
-  'md': 832px,
-  'lg': 1024px,
-  'xl': 1152px
-);
-```
-
-Dynamic spacing (whether or not each margin and padding class is generated for each breakpoint).
-```
-$dynamic_spacing: true;
-```
-
-The deliminator used to replace a `.`
-`mb1_5` = `margin-bottom: 1.5rem`
-```
-$decimal_deliminator: '_';
-```
-
-Dynamic grid (hether or not each `col-<i>` class is generated for each breakpoint).
-```
-$dynamic-grid: true;
-```
-
-Amount of columns in the grid.
-```
-$grid-columns: 12;
-```
-
-Color map.
-```
-$colors: (
-  'black': #000,
-  'white': #FFF,
-  'blue': #0A3862
-);
-```
+| variable | description | default |
+| --- | --- | --- |
+| `$grid-columns` | Amount of columns in the grid. | `12` |
+| `$colors` | Color map use for `color-<color>`, `bg-color-<color>`, and `border-color-<color>` classes. | `('black': #000, 'white': #FFF, 'blue': #0A3862);` |
+| `$breakpoints` | Media query breakpoints. | `('sm': 640px, 'md': 832px, 'lg': 1024px, 'xl': 1152px)` |
+| `$spacing-units` | Spacing units for padding and margin. | `0rem, .25rem, .5rem, .75rem, 1rem, 2rem, 3rem, 4rem, 6rem, 8rem;` |
+| `$aspect-ratios` | Ratios for `.aspect-<ratio>` utility class. | `('square': (1, 1), 'landscape': (16, 9), 'portrait': (2, 3));`|
+| `$dynamic_spacing` | Whether or not each margin and padding class is generated for each breakpoint. | `true` |
+| `$decimal_deliminator` | The deliminator used to replace a `.` | `'_'` |
+| `$dynamic-grid` | Whether or not each `col-<i>` class is generated for each breakpoint. | `true` |


### PR DESCRIPTION
- switches all usage of `yarn install` to the correct function `yarn add`
- adds directions for `create-react-app@2.0.0+` that supports SCSS modules as a first-class citizen
- removes reference to the incorrect npm package `basement` and uses the proper git link for basement install
- uses global markdown table format to for Settings' default layout