### PR TITLE
Fix n-down media query mixin generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanctucompu/basement",
-  "version": "1.2.2",
+  "version": "1.2.1",
   "description": "Ground floor CSS utility classes",
   "repository": "https://github.com/sanctuarycomputer/basement.git",
   "author": "Sanctuary Computer <dev@sanctuary.computer>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanctucompu/basement",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Ground floor CSS utility classes",
   "repository": "https://github.com/sanctuarycomputer/basement.git",
   "author": "Sanctuary Computer <dev@sanctuary.computer>",
@@ -11,6 +11,7 @@
   "scripts": {
     "watch": "node-sass -w --output-style compact --source-map dist/basement.css.map src/index.scss dist/basement.css;",
     "watch:min": "node-sass -w --output-style compressed --source-map dist/basement.min.css.map src/index.scss dist/basement.min.css;",
-    "build": "node-sass --output-style compact --source-map dist/basement.css.map src/index.scss dist/basement.css; node-sass --output-style compressed --source-map dist/basement.min.css.map src/index.scss dist/basement.min.css;"
+    "build": "node-sass --output-style compact --source-map dist/basement.css.map src/index.scss dist/basement.css; node-sass --output-style compressed --source-map dist/basement.min.css.map src/index.scss dist/basement.min.css;",
+    "prepare": "yarn build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanctucompu/basement",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Ground floor CSS utility classes",
   "repository": "https://github.com/sanctuarycomputer/basement.git",
   "author": "Sanctuary Computer <dev@sanctuary.computer>",


### PR DESCRIPTION
Hiya,

I accidentally pushed my intended change to main. [see here](https://github.com/sanctuarycomputer/basement/commit/459f703772351143fa527a52adcfb01760572723)

Then I was an impatient bad boy and published at `1.2.1`

Using a mixin like `@include media('md-down') { ... }` wouldn't work because the SASS variable inside `calc(...)` needs to be escaped.

I've used yarn link to test this locally and it's now doing the trick.

Assuming all is well, we just need an updated changelog. I was going to add this manually but it looks like it's generated somehow? So I didn't want to fuss.